### PR TITLE
Add libroboint

### DIFF
--- a/setup/libroboint-inst.sh
+++ b/setup/libroboint-inst.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+LIBURL=https://github.com/nxdefiant/libroboint/archive/
+LIBFILE=0.5.3.zip
+IDIR=libroboint-0.5.3
+
+echo "====================================================="
+echo "       downloading and building of libroboint "
+echo "====================================================="
+
+# download libroboint sources
+wget $LIBURL$LIBFILE
+unzip $LIBFILE
+
+# install libusb-dev
+apt-get install libusb-dev
+
+# build
+cd $IDIR
+cmake .
+make
+make doc
+
+# install
+make install
+
+# install python
+make python
+
+#udev rules
+cp udev/fischertechnik.rules /etc/udev/rules.d/
+
+# clean up
+cd ..
+rm -f $LIBFILE
+rm -fr $IDIR
+
+echo "====================================================="
+echo "                libroboint finished"
+echo "====================================================="

--- a/setup/libroboint-inst.sh
+++ b/setup/libroboint-inst.sh
@@ -30,8 +30,14 @@ make python
 #udev rules
 cp udev/fischertechnik.rules /etc/udev/rules.d/
 
-# clean up
+# python3 compatibility 'patch'
 cd ..
+wget https://github.com/PeterDHabermehl/libroboint-py3/raw/master/robointerface.py
+wget https://github.com/PeterDHabermehl/libroboint-py3/raw/master/robointerface.pyc
+mv robointerface.py /usr/local/lib/python3.4/dist-packages/
+mv robointerface.pyc /usr/local/lib/python3.4/dist-packages/
+
+# clean up
 rm -f $LIBFILE
 rm -fr $IDIR
 

--- a/setup/tx-pi-setup.sh
+++ b/setup/tx-pi-setup.sh
@@ -231,6 +231,12 @@ for i in 24:23 28:24 32:24; do
     sed -i "s/^\(\s*font:\)\s*${from}px/\1 ${to}px/" $STYLE
 done
 
+# install libroboint
+wget https://github.com/harbaum/tx-pi/raw/master/setup/libroboint-inst.sh
+chmod a+x libroboint-inst.sh
+./libroboint-inst.sh
+rm -f libroboint-inst.sh
+
 # remove useless ftgui
 rm -rf /opt/ftc/apps/system/ftgui
 


### PR DESCRIPTION
libroboint will be built from original github source
python3 module is added separately as an interim solution. 
as soon as libroboint itself was updated to py3 compatibility, the patch will be removed.